### PR TITLE
Fix flaky test

### DIFF
--- a/tests/test_running_nose.py
+++ b/tests/test_running_nose.py
@@ -16,7 +16,7 @@ this_folder = os.path.abspath(os.path.dirname(__file__))
 test_folder = os.path.join(this_folder, "examples", "test_examples")
 
 regexes = {
-      "test_result": re.compile(r'((?P<name>[^ ]+) \((?P<home>[^\)]+)\)|(?P<full_test>[^ ]+)) ... ok')
+      "test_result": re.compile(r'((?P<name>[^ ]+) \((?P<home>[^\)]+)\)|(?P<full_test>[^ ]+))( ... )?ok')
     }
 
 describe TestCase, "Running nose":


### PR DESCRIPTION
A test fails the match condition on this regex sometimes, by displaying only "ok" in the output. Not on every run, it smells like a race condition. It seems harmless enough, though, since the test reporting "ok" obviously succeeds.